### PR TITLE
Add support for FreeBSD platform. Tested on: FreeBSD 11, FreeBSD 12

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,22 @@ class prometheus::config {
           content => template("${module_name}/sysconfig/prometheus"),
         }
       }
+      'FreeBSD': {
+        file { '/etc/rc.conf.d/prometheus':
+          ensure  => 'file',
+          mode    => '0644',
+          owner   => $::prometheus::user,
+          group   => $::prometheus::group,
+          content => template("${module_name}/freebsd/prometheus"),
+        }
+        file { '/usr/local/etc/rc.d/prometheus':
+          ensure  => 'file',
+          mode    => '0555',
+          owner   => 'root',
+          group   => 'wheel',
+          content => template("${module_name}/freebsd/prometheus_rcconf.erb"),
+        }
+      }
     }
   }
   if $::prometheus::manage_config {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,15 +2,18 @@
 #
 class prometheus::config {
   if $::prometheus::manage_as == 'service' {
-    file { '/etc/sysconfig/prometheus':
-      ensure  => 'file',
-      mode    => '0644',
-      owner   => $::prometheus::user,
-      group   => $::prometheus::group,
-      content => template("${module_name}/sysconfig/prometheus"),
+    case $::osfamily {
+      'RedHat', 'Linux': {
+        file { '/etc/sysconfig/prometheus':
+          ensure  => 'file',
+          mode    => '0644',
+          owner   => $::prometheus::user,
+          group   => $::prometheus::group,
+          content => template("${module_name}/sysconfig/prometheus"),
+        }
+      }
     }
   }
-
   if $::prometheus::manage_config {
     $content = template("${module_name}/prometheus.yml.erb")
   } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,6 @@ class prometheus::params {
   $service_name = 'prometheus'
   $user = 'prometheus'
   $group = 'prometheus'
-  $config_dir = '/etc/prometheus'
   $manage_config = true
   $manage_as = 'service'
   $container_image = 'docker.io/prom/prometheus:latest'
@@ -52,5 +51,14 @@ class prometheus::params {
   $extra_options = undef
 
   $config = {
+  }
+
+  case $::osfamily {
+    'RedHat', 'Linux': {
+      $config_dir = '/etc/prometheus'
+    }
+    'FreeBSD': {
+      $config_dir = '/usr/local/etc'
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -37,6 +37,12 @@
 			"operatingsystemrelease": [ "21"
 			]
 		}
+		},{
+			"operatingsystem": "FreeBSD",
+			"operatingsystemrelease": [ "11",
+				"12"
+			]
+		}
 	],
 	"requirements": [],
 	"tags": [ "prometheus",

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,6 @@
 			"operatingsystem": "Fedora",
 			"operatingsystemrelease": [ "21"
 			]
-		}
 		},{
 			"operatingsystem": "FreeBSD",
 			"operatingsystemrelease": [ "11",

--- a/templates/freebsd/prometheus
+++ b/templates/freebsd/prometheus
@@ -1,0 +1,9 @@
+# File managed by puppet
+#
+prometheus_enable="YES"
+prometheus_args="<%= scope.function_template(['prometheus/_prometheus.erb']) %>"
+prometheus_user="<%= scope['prometheus::user'] -%>"
+prometheus_group="<%= scope['prometheus::group'] -%>"
+<% if @storage_local_path -%>
+prometheus_data_dir="<%= scope['prometheus::storage_local_path'] -%>
+<% end -%>

--- a/templates/freebsd/prometheus_rcconf.erb
+++ b/templates/freebsd/prometheus_rcconf.erb
@@ -1,0 +1,65 @@
+#!/bin/sh
+# This file is managed by Puppet, any changes will be overwritten
+
+# PROVIDE: prometheus
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+#
+# Add the following lines to /etc/rc.conf.local or /etc/rc.conf
+# to enable this service:
+#
+# prometheus_enable (bool):     Set to NO by default
+#                               Set it to YES to enable prometheus
+# prometheus_user (string):     Set user to run prometheus
+#                               Default is "prometheus"
+# prometheus_group (string):    Set group to run prometheus
+#                               Default is "prometheus"
+# prometheus_data_dir (string): Set dir to run prometheus in
+#                               Default is "/var/db/prometheus"
+# prometheus_log_file (string): Set file that prometheus will log to
+#                               Default is "/var/log/prometheus.log"
+# prometheus_args (string):     Set additional command line arguments
+#                               Default is ""
+
+. /etc/rc.subr
+
+name=prometheus
+rcvar=prometheus_enable
+
+load_rc_config $name
+
+: ${prometheus_enable:="NO"}
+: ${prometheus_user:="prometheus"}
+: ${prometheus_group:="prometheus"}
+: ${prometheus_config:="/usr/local/etc/prometheus.yml"}
+: ${prometheus_data_dir:="/var/db/prometheus"}
+: ${prometheus_log_file:="/var/log/prometheus.log"}
+: ${prometheus_args:=""}
+
+pidfile=/var/run/prometheus.pid
+required_files="${prometheus_config}"
+command="/usr/sbin/daemon"
+procname="/usr/local/bin/prometheus"
+sig_reload=HUP
+extra_commands="reload"
+command_args="-p ${pidfile} /usr/bin/env ${procname} \
+                -storage.local.path=${prometheus_data_dir} \
+                ${prometheus_args} > ${prometheus_log_file} 2>&1"
+
+start_precmd=prometheus_startprecmd
+
+prometheus_startprecmd()
+{
+    if [ ! -e ${pidfile} ]; then
+        install -o ${prometheus_user} -g ${prometheus_group} /dev/null ${pidfile};
+    fi
+    if [ ! -f "${prometheus_log_file}" ]; then
+        install -o ${prometheus_user} -g ${prometheus_group} -m 640 /dev/null ${prometheus_log_file};
+    fi
+    if [ ! -d ${prometheus_data_dir} ]; then
+        install -d -o ${prometheus_user} -g ${prometheus_group} -m 750 ${prometheus_data_dir}
+    fi
+}
+
+load_rc_config $name
+run_rc_command "$1"


### PR DESCRIPTION
- add support for FreeBSD platform;
- **params.pp**: split OS/distros -depened params in corresponding cases;
- On FreeBSD, all config files placed in **/usr/local/** prefix, so need to define alternative config dir;

~~~
% ps axf |grep prom
10560  -  IJ   0:00.97 /usr/local/bin/prometheus -config.file=/usr/local/etc/prometheus.yml -storage.local.path=/var/db/prometheus
~~~

Tested on:
- FreeBSD 11.0-RELEASE
- FreeBSD 12-HEAD (aka Current)

